### PR TITLE
Fix interrupt handling guard and safe 16-bit memory access

### DIFF
--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -48,7 +48,7 @@ impl Cpu {
         // 5. Jump to the starting address of the interrupt.
 
         // If CPU is halted and interrupts are disabled, do nothing.
-        if !self.halt && !self.ime {
+        if self.halt && !self.ime {
             return 0;
         }
 

--- a/src/mmu/mod.rs
+++ b/src/mmu/mod.rs
@@ -240,7 +240,9 @@ impl Memory for Mmu {
 
     /// Read a word (u16) from memory
     fn read16(&self, addr: u16) -> u16 {
-        u16::from(self.read8(addr)) | (u16::from(self.read8(addr + 1)) << 8)
+        let lo = self.read8(addr);
+        let hi = self.read8(addr.wrapping_add(1));
+        u16::from(lo) | (u16::from(hi) << 8)
         /*let lo = self.read8(addr);
         let hi = self.read8(addr + 1);
         u16::from_le_bytes([lo, hi])*/
@@ -253,7 +255,7 @@ impl Memory for Mmu {
             val, addr
         );
         self.write8(addr, (val & 0xFF) as u8);
-        self.write8(addr + 1, (val >> 8) as u8);
+        self.write8(addr.wrapping_add(1), (val >> 8) as u8);
     }
 
     fn cycle(&mut self, ticks: u32) -> u32 {


### PR DESCRIPTION
## Summary
- correct halt/IME gating so interrupts are skipped only when the CPU is halted with interrupts disabled
- handle 16-bit MMU reads/writes with wrapping increments to avoid overflow at address boundaries

## Testing
- cargo fmt
- cargo test *(fails to complete in time in this environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693390f9bf488326859169476da2081d)