### PR TITLE
Fix timer configuration and cartridge title parsing

### DIFF
--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -11,7 +11,7 @@ pub trait Cartridge: Memory {
     /// Cartridge Tile
     fn title(&self) -> String {
         let mut title = String::new();
-        for i in 0x134..0x143 {
+        for i in 0x134..=0x143 {
             match self.read8(i) {
                 0x00 => break,
                 _ => title.push(self.read8(i) as char),

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -75,7 +75,6 @@ impl Timer {
                         0x03 => 256,
                         _ => panic!(""),
                     };
-                    self.reg.tima = self.reg.tma;
                 }
                 self.reg.tac = v;
             }


### PR DESCRIPTION
## Summary
- ensure cartridge title parsing covers the full 16-byte header range
- prevent TAC writes from prematurely reloading TIMA when changing timer frequency

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693390f9bf488326859169476da2081d)