### PR TITLE
Fix IME scheduling and timer frequency bug

### DIFF
--- a/src/cpu/execute.rs
+++ b/src/cpu/execute.rs
@@ -27,7 +27,12 @@ impl Cpu {
             0x00 => {}
 
             // 0x10 - STOP
-            0x10 => {}
+            0x10 => {
+                // Until joypad wake-up handling exists, treat STOP as HALT so
+                // the CPU pauses instead of continuing to execute instructions
+                // unexpectedly.
+                self.halt = true;
+            }
 
             // 0x76 - HALT
             0x76 => {
@@ -37,13 +42,18 @@ impl Cpu {
             // 0xF3 - DI - Disable interrupts
             // NOTE: The IME should be changed not immediately, but after this instruction executes.
             0xF3 => {
+                // DI takes effect after the instruction finishes, so clear any
+                // pending enables and disable IME immediately after
+                // execution.
+                self.ime_enable_delay = None;
                 self.ime = false;
             }
 
             // 0xFB - EI - Enable interrupts
             // NOTE: The IME should be changed not immediately, but after this instruction executes.
             0xFB => {
-                self.ime = true;
+                // EI enables IME after the *next* instruction completes.
+                self.ime_enable_delay = Some(1);
             }
 
             // LD r8, d8

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -23,6 +23,11 @@ pub struct Cpu {
     /// Interrupt Master Enable Flag (IME)
     ime: bool,
 
+    /// Delayed IME enable. EI takes effect after the following instruction has
+    /// completed, so we track a small countdown to flip the IME flag at the
+    /// right time.
+    ime_enable_delay: Option<u8>,
+
     /// Halt flag, for stopping CPU operation.
     halt: bool,
 }
@@ -138,12 +143,21 @@ impl Cpu {
             mem,
             boot_rom_enabled: true,
             ime: false,
+            ime_enable_delay: None,
             halt: false,
         }
     }
 
     /// Cycle the CPU for a single instruction - Fetch, decode, execute
     pub fn cycle(&mut self) -> u32 {
+        // Apply any pending IME changes that should become active before we
+        // fetch the next instruction (for example, after the instruction
+        // following EI has completed).
+        if let Some(0) = self.ime_enable_delay {
+            self.ime = true;
+            self.ime_enable_delay = None;
+        }
+
         //self._debug_print_state();
         let mut ticks = 0;
 
@@ -151,6 +165,15 @@ impl Cpu {
         if !self.halt {
             let op = self.fetch();
             ticks += self.op_execute(op);
+
+            // Update delayed IME state for EI. The enable happens after the
+            // *next* instruction, so we tick the delay down once per
+            // instruction boundary.
+            if let Some(delay) = self.ime_enable_delay.as_mut() {
+                if *delay > 0 {
+                    *delay -= 1;
+                }
+            }
         } else {
             info!("CPU halted!");
             ticks += 1;

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -75,7 +75,6 @@ impl Timer {
                         0x03 => 256,
                         _ => panic!(""),
                     };
-                    self.reg.tima = self.reg.tma;
                 }
                 self.reg.tac = v;
             }


### PR DESCRIPTION
## Summary
- delay EI enable to occur after the following instruction and clear pending enables on DI
- implement STOP as a halt so the CPU no longer runs past the stop instruction
- keep TIMA unchanged when changing timer frequency to match DMG behavior

## Testing
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693390f9bf488326859169476da2081d)