### PR TITLE
Fix MBC1 banking and RAM allocation

### DIFF
--- a/src/cartridge/mbc1.rs
+++ b/src/cartridge/mbc1.rs
@@ -107,19 +107,29 @@ impl Mbc1 {
         };
         bank as usize
     }
+
+    fn fixed_rom_bank(&self) -> usize {
+        match self.bank_mode {
+            BankMode::Rom => 0x00,
+            BankMode::Ram => (self.bank & 0x60) as usize,
+        }
+    }
 }
 
 impl Memory for Mbc1 {
     fn read8(&self, addr: u16) -> u8 {
         match addr {
-            0x0000..=0x3fff => self.rom[addr as usize],
+            0x0000..=0x3fff => {
+                let bank = self.fixed_rom_bank();
+                self.rom[bank * 0x4000 + addr as usize]
+            }
             0x4000..=0x7fff => {
                 let bank = self.rom_bank();
                 let offset = addr as usize - 0x4000;
                 self.rom[bank * 0x4000 + offset]
             }
             0xa000..=0xbfff => {
-                if self.ram_enabled {
+                if self.ram_enabled && !self.ram.is_empty() {
                     let bank = self.ram_bank();
                     let offset = addr as usize - 0xa000;
                     self.ram[bank * 0x2000 + offset]
@@ -151,7 +161,7 @@ impl Memory for Mbc1 {
                 };
             }
             0xa000..=0xbfff => {
-                if self.ram_enabled {
+                if self.ram_enabled && !self.ram.is_empty() {
                     let bank = self.ram_bank();
                     let offset = addr as usize - 0xa000;
                     self.ram[bank * 0x2000 + offset] = val;

--- a/src/cartridge/mod.rs
+++ b/src/cartridge/mod.rs
@@ -6,6 +6,17 @@ use crate::mmu::memory::Memory;
 
 use self::{header::*, mbc::*, mbc1::*};
 
+fn ram_size_bytes(size: RamSize) -> usize {
+    match size {
+        RamSize::None => 0,
+        RamSize::Kb2Unused => 0x800,
+        RamSize::Kb8 => 0x2000,
+        RamSize::Kb32 => 0x8000,
+        RamSize::Kb128 => 0x20000,
+        RamSize::Kb64 => 0x10000,
+    }
+}
+
 /// Cartridge represents a Gameboy ROM
 pub trait Cartridge: Memory {
     /// Cartridge Tile
@@ -67,9 +78,15 @@ pub trait Cartridge: Memory {
 /// Initialize a new Cartridge.
 pub fn new(path: String) -> Box<dyn Cartridge> {
     let rom_data = std::fs::read(path.clone()).unwrap();
-    let cart: Box<dyn Cartridge> = match CartridgeType::try_from(rom_data[0x147]).unwrap() {
+    let cartridge_type = CartridgeType::try_from(rom_data[0x147]).unwrap();
+    let ram_size = RamSize::try_from(rom_data[0x149]).unwrap();
+    let ram = ram_size_bytes(ram_size);
+
+    let cart: Box<dyn Cartridge> = match cartridge_type {
         CartridgeType::RomOnly => Box::new(RomOnly::new(rom_data)),
-        CartridgeType::Mbc1 => Box::new(Mbc1::new(rom_data, vec![])),
+        CartridgeType::Mbc1 | CartridgeType::Mbc1Ram | CartridgeType::Mbc1RamBattery => {
+            Box::new(Mbc1::new(rom_data, vec![0; ram]))
+        }
         //TODO: Implement other cartridge types.
         _ => todo!("Unsupported cartridge type: {:?}", path),
     };


### PR DESCRIPTION
## Summary
- allocate cartridge RAM based on header metadata when loading MBC1 cartridges
- guard RAM access when RAM is not present and enable fixed bank selection during MBC1 RAM banking mode

## Testing
- cargo test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693390f9bf488326859169476da2081d)